### PR TITLE
Support rescoping through module attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ defmodule User do
 end
 ```
 
+It is possible to add a `@rescope` attribute to your schema with an external function.
+
+```elixir
+defmodule SoftDelete do
+  import Ecto.Query, only: [from: 2]
+
+  def exclude_deleted(query) do
+    from(q in query, where: q.is_deleted == false)
+  end
+end
+
+defmodule User do
+  use Ecto.Schema
+  use Ecto.Rescope
+
+  @rescope &SoftDelete.exclude_deleted/1
+  schema "users" do
+    field(:is_deleted, :boolean)
+  end
+
+end
+```
+
 When we want to query without the default scoping applied, we can do so with `unscoped/0`, 
 which is added by the `rescope/1` macro.
 

--- a/test/ecto_rescope_test.exs
+++ b/test/ecto_rescope_test.exs
@@ -62,6 +62,24 @@ defmodule Ecto.RescopeTest do
       assert Enum.member?(users, bob)
       assert Enum.member?(users, charlie)
     end
+
+    test "raises an exception with an invalid term" do
+      assert_raise RuntimeError, ~r/#{__MODULE__}/, fn ->
+        defmodule TestSchema do
+          use Ecto.Rescope
+          @rescope :foo
+        end
+      end
+    end
+
+    test "raises an exception with an anonymous function" do
+      assert_raise RuntimeError, ~r/#{__MODULE__}/, fn ->
+        defmodule TestSchema do
+          use Ecto.Rescope
+          @rescope fn x -> x end
+        end
+      end
+    end
   end
 
   ## PRIVATE FUNCTIONS

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -1,14 +1,12 @@
 defmodule User do
   use Ecto.Schema
+  use Ecto.Rescope
 
-  import Ecto.Rescope
-
+  @rescope &SoftDelete.exclude_deleted/1
   schema "users" do
     field(:name, :string)
     field(:is_deleted, :boolean, default: false)
 
     belongs_to(:team, Team)
   end
-
-  rescope(&SoftDelete.exclude_deleted/1)
 end


### PR DESCRIPTION
This PR adds an optional compile-time macro that allows rescope queries to be defined as a module attribute. The goal was to make things more inline with current Ecto attributes such as `@schema_prefix`  which give better visual cues.

Example: 
```elixir
  @rescope &SoftDelete.exclude_deleted/1
  schema "users" do
    field(:is_deleted, :boolean)
  end
```

instead of 
```elixir
  schema "users" do
    field(:is_deleted, :boolean)
  end

  rescope(&SoftDelete.exclude_deleted/1)
```